### PR TITLE
Fix target padding to be consistent throughout screens

### DIFF
--- a/src/components/MapScreens/MapScreen.js
+++ b/src/components/MapScreens/MapScreen.js
@@ -181,7 +181,8 @@ const style = StyleSheet.create({
   },
   overlay: {
     position: 'absolute',
-    bottom: 0
+    bottom: 0,
+    padding: 0
   },
   searchContainer: {
     backgroundColor: 'transparent',

--- a/src/components/common/Target.js
+++ b/src/components/common/Target.js
@@ -62,7 +62,7 @@ const Target = (props) => {
   }
 
   return (
-    <View>
+    <View style={{ padding: 10 }}>
       <Text h4 style={{ fontWeight: 'bold' }}>{name}</Text>
 
       { type && <Text style={style.h5}>{`Tyyppi: ${type}`}</Text> }


### PR DESCRIPTION
A very minor visual fix to make the Target in TargetScreen have the same padding as the one in MapScreen.